### PR TITLE
feat(omni): add omni setup script

### DIFF
--- a/omni/README.md
+++ b/omni/README.md
@@ -1,0 +1,18 @@
+# Omni
+
+> [!IMPORTANT]
+>
+> Tested on Ubuntu 24.04 Standard amd64 LXC on Proxmox 8.4.1
+>
+> In case you're using LXC, make sure to enable FUSE features.
+> And add these lines to your container config (/etc/pve/lxc/xxx.conf):
+>
+> ```
+> lxc.mount.entry: /dev/fuse dev/fuse none bind,create=file,optional
+> lxc.mount.auto: cgroup:rw
+> ```
+>
+> And add device passthrough to your container:
+> `/dev/net/tun` for wireguard support
+
+[See the full documentation here](https://omni.siderolabs.com/how-to-guides/self_hosted/index)

--- a/omni/compose.yaml
+++ b/omni/compose.yaml
@@ -1,0 +1,35 @@
+name: omni-on-prem
+version: "3"
+services:
+  omni:
+    container_name: omni
+    image: "ghcr.io/siderolabs/omni:${OMNI_IMG_TAG}"
+    devices:
+      - /dev/net/tun
+    volumes:
+      - ${ETCD_VOLUME_PATH}:/_out/etcd
+      - ${ETCD_ENCRYPTION_KEY}:/omni.asc
+      - ${TLS_CERT}:/tls.crt
+      - ${TLS_KEY}:/tls.key
+    network_mode: "host"
+    cap_add:
+      - NET_ADMIN
+    command: >
+      --account-id=${OMNI_ACCOUNT_UUID}
+      --name=${NAME}
+      --cert=/tls.crt
+      --key=/tls.key
+      --machine-api-cert=/tls.crt
+      --machine-api-key=/tls.key
+      --private-key-source='file:///omni.asc'
+      --event-sink-port=${EVENT_SINK_PORT}
+      --bind-addr=${BIND_ADDR}
+      --machine-api-bind-addr=${MACHINE_API_BIND_ADDR}
+      --k8s-proxy-bind-addr=${K8S_PROXY_BIND_ADDR}
+      --advertised-api-url=${ADVERTISED_API_URL}
+      --advertised-kubernetes-proxy-url=${ADVERTISED_K8S_PROXY_URL}
+      --siderolink-api-advertised-url=${SIDEROLINK_ADVERTISED_API_URL}
+      --siderolink-wireguard-advertised-addr=${SIDEROLINK_WIREGUARD_ADVERTRISED_ADDR}
+      --initial-users=${INITIAL_USER_EMAILS}
+      ${AUTH}
+    restart: always

--- a/omni/install.sh
+++ b/omni/install.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+
+install_curl() {
+  echo "🔍 Checking for curl..."
+  if ! command -v curl &>/dev/null; then
+    echo "⚠️ curl is not installed."
+
+    if [ -f /etc/debian_version ]; then
+      echo "📦 Installing curl on Debian/Ubuntu..."
+      sudo apt update && sudo apt install -y curl || {
+        echo "❌ curl installation failed (apt)."
+        exit 1
+      }
+    elif [ -f /etc/redhat-release ]; then
+      echo "📦 Installing curl on RHEL/CentOS..."
+      sudo yum install -y curl || {
+        echo "❌ curl installation failed (yum)."
+        exit 1
+      }
+    else
+      echo "🚫 Unsupported OS. Please install curl manually."
+      exit 1
+    fi
+
+    command -v curl &>/dev/null && echo "✅ curl installed successfully." || {
+      echo "❌ curl still not found after attempted installation."
+      exit 1
+    }
+  else
+    echo "✅ curl is already installed."
+  fi
+}
+
+install_snap() {
+  echo "🔍 Checking for Snap..."
+  if ! command -v snap &>/dev/null; then
+    echo "⚠️ Snap is not installed."
+
+    if [ -f /etc/debian_version ]; then
+      echo "📦 Installing Snapd on Debian/Ubuntu..."
+      sudo apt update && sudo apt install -y snapd
+      sudo systemctl enable --now snapd.socket
+      echo "🔁 Rebooting system to finish Snap install..."
+      sudo reboot
+    else
+      echo "🚫 Snap install not supported on this OS. Please install manually."
+      exit 1
+    fi
+  else
+    echo "✅ Snap is already installed."
+  fi
+}
+
+install_certbot() {
+  echo "🔍 Checking for Certbot..."
+  if ! command -v certbot &>/dev/null; then
+    echo "⚙️ Installing Certbot using Snap..."
+
+    sudo snap install core && sudo snap refresh core
+    sudo snap install --classic certbot
+    sudo snap set certbot trust-plugin-with-root=ok
+    sudo snap install certbot-dns-cloudflare
+
+    command -v certbot &>/dev/null && echo "✅ Certbot installed successfully." || {
+      echo "❌ Certbot installation failed."
+      exit 1
+    }
+  else
+    echo "✅ Certbot is already installed."
+  fi
+}
+
+install_docker() {
+  echo "🔍 Checking for Docker..."
+
+  if ! command -v docker &>/dev/null; then
+    echo "⚙️ Docker is not installed. Installing via get.docker.io..."
+    curl -fsSL https://get.docker.io | sh
+
+    if [ $? -eq 0 ]; then
+      echo "✅ Docker installed successfully."
+      sudo usermod -aG docker "$USER"
+      echo "👥 Added current user to Docker group (log out and back in to apply)."
+    else
+      echo "❌ Docker installation failed."
+      exit 1
+    fi
+  else
+    echo "✅ Docker is already installed."
+  fi
+}
+
+request_cert() {
+  echo -e "\n🔐 Enter your Cloudflare API Token (input hidden):"
+  read -s CF_API_TOKEN
+  echo "🔑 Cloudflare API token received."
+
+  CLOUDFLARE_CREDS_FILE=~/creds.ini
+  echo "📝 Writing credentials to $CLOUDFLARE_CREDS_FILE..."
+  cat <<EOF >"$CLOUDFLARE_CREDS_FILE"
+# Cloudflare API token used by Certbot
+dns_cloudflare_api_token = $CF_API_TOKEN
+EOF
+  chmod 600 "$CLOUDFLARE_CREDS_FILE"
+  echo "🔒 Credentials saved with secure permissions."
+
+  echo -e "\n🌐 Enter the domain name of Omni (e.g., omni.example.com):"
+  read DOMAIN_NAME
+  echo "📛 Omni Domain: $DOMAIN_NAME"
+
+  echo "🚀 Requesting certificate for $DOMAIN_NAME..."
+  sudo certbot certonly \
+    --dns-cloudflare \
+    --dns-cloudflare-credentials "$CLOUDFLARE_CREDS_FILE" \
+    -d "$DOMAIN_NAME"
+
+  [ $? -eq 0 ] && echo "✅ Certificate obtained for $DOMAIN_NAME." || {
+    echo "❌ Failed to obtain certificate."
+    exit 1
+  }
+}
+
+generate_env_file() {
+  echo -e "\n🛠 Generating environment configuration..."
+
+  read -p "🌐 Enter your base domain (e.g., example.com): " DOMAIN
+  read -p "💻 Enter machine IP (for WireGuard): " MACHINE_IP
+  read -p "📧 Enter initial user emails: " INITIAL_EMAILS
+  read -p "🔐 Enter Auth0 domain: " AUTH0_DOMAIN
+  read -p "🆔 Enter Auth0 client ID: " AUTH0_CLIENT_ID
+
+  UUID=$(uuidgen)
+  TEMPLATE_FILE="omni.env.template"
+  OUTPUT_FILE="omni.env"
+
+  sed -e "s|<UUID>|$UUID|g" \
+    -e "s|<DOMAIN>|$DOMAIN|g" \
+    -e "s|<MACHINE_IP>|$MACHINE_IP|g" \
+    -e "s|<INIT_EMAIL>|$INITIAL_EMAILS|g" \
+    -e "s|<AUTH0_DOMAIN>|$AUTH0_DOMAIN|g" \
+    -e "s|<AUTH0_CLIENT_ID>|$AUTH0_CLIENT_ID|g" \
+    "$TEMPLATE_FILE" >"$OUTPUT_FILE"
+
+  echo "✅ $OUTPUT_FILE generated successfully."
+}
+
+generate_gpg_key() {
+  echo "🔐 Generating GPG key..."
+
+  META_UID="Omni (Used for etcd data encryption) <$INITIAL_EMAILS>"
+  gpg --batch --pinentry-mode loopback --passphrase '' \
+    --quick-generate-key "$META_UID" rsa4096 cert never
+
+  KEY_ID=$(gpg --list-keys --with-colons "$INITIAL_EMAILS" | awk -F: '/^pub/ {print $5; exit}')
+  FINGERPRINT=$(gpg --list-secret-keys --with-colons "$INITIAL_EMAILS" | awk -F: '/^fpr:/ {print $10; exit}')
+
+  if [ -z "$KEY_ID" ] || [ -z "$FINGERPRINT" ]; then
+    echo "❌ Failed to generate or locate GPG key/fingerprint."
+    exit 1
+  fi
+
+  echo "➕ Adding encryption subkey..."
+  gpg --batch --pinentry-mode loopback --passphrase '' \
+    --quick-add-key "$FINGERPRINT" rsa4096 encr never
+
+  echo "📦 Exporting secret key to omni.asc..."
+  gpg --armor --output omni.asc --export-secret-key "$INITIAL_EMAILS"
+  echo "✅ GPG key generated and exported."
+}
+
+start_omni() {
+  echo "🚢 Starting Omni using Docker Compose..."
+  docker compose --env-file omni.env up -d
+
+  if [ $? -eq 0 ]; then
+    echo "✅ Omni is running."
+    echo "🔗 Access it at: https://$DOMAIN_NAME"
+  else
+    echo "❌ Failed to start Omni."
+    exit 1
+  fi
+}
+
+install_curl
+install_snap
+install_docker
+install_certbot
+request_cert
+generate_env_file
+generate_gpg_key
+start_omni

--- a/omni/omni.env.template
+++ b/omni/omni.env.template
@@ -1,0 +1,36 @@
+# Omni
+OMNI_IMG_TAG=v0.49.1
+OMNI_ACCOUNT_UUID=<UUID>
+NAME=omni
+EVENT_SINK_PORT=8091
+
+## Keys and Certs
+TLS_CERT=/etc/letsencrypt/live/<DOMAIN>/fullchain.pem
+TLS_KEY=/etc/letsencrypt/live/<DOMAIN>/privkey.pem
+ETCD_VOLUME_PATH=/root/omni/etcd
+ETCD_ENCRYPTION_KEY=/root/omni/omni.asc
+
+## Binding
+BIND_ADDR=0.0.0.0:443
+MACHINE_API_BIND_ADDR=0.0.0.0:8090
+K8S_PROXY_BIND_ADDR=0.0.0.0:8100
+
+## Domains and Advertisements
+OMNI_DOMAIN_NAME="<DOMAIN>"
+ADVERTISED_API_URL="https://<DOMAIN>"
+SIDEROLINK_ADVERTISED_API_URL="https://<DOMAIN>:8090/"
+ADVERTISED_K8S_PROXY_URL="https://<DOMAIN>:8100/"
+SIDEROLINK_WIREGUARD_ADVERTRISED_ADDR="<MACHINE_IP>:50180"
+
+## Users
+INITIAL_USER_EMAILS=<INIT_EMAIL>
+
+## Authentication
+#Auth0
+AUTH='--auth-auth0-enabled=true \
+      --auth-auth0-domain=<AUTH0_DOMAIN> \
+      --auth-auth0-client-id=<AUTH0_CLIENT_ID>'
+# Or, when using SAML:
+# AUTH='--auth-saml-enabled=true \
+#       --auth-saml-url=<saml-url>'
+#Only one AUTH version can be used at a time, so ensure to remove the one you don't use.


### PR DESCRIPTION
This pull request introduces a comprehensive setup for deploying Omni on-premises, including configuration files, installation scripts, and documentation. The changes focus on providing a streamlined deployment process, environment configuration, and detailed setup instructions.

### Deployment and Configuration

* Added `compose.yaml` to define the Docker Compose configuration for running Omni, including services, volumes, and network settings. This file ensures that the Omni service is deployed with the required dependencies and permissions.
* Created `omni.env.template` to serve as a template for environment variables, specifying key configurations such as domain names, API URLs, and authentication settings.

### Installation and Setup Automation

* Added `install.sh`, a comprehensive installation script that automates the setup of prerequisites (e.g., `curl`, `snap`, `certbot`, `docker`), certificate generation, environment file creation, GPG key generation, and starting the Omni service.

### Documentation

* Updated `README.md` with detailed instructions for deploying Omni, including LXC-specific configuration, required FUSE features, and a link to the full documentation.